### PR TITLE
Remove django_cleanup

### DIFF
--- a/dash_stack_dashboard/settings.py
+++ b/dash_stack_dashboard/settings.py
@@ -55,7 +55,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django_cleanup',
     'app',
     'authcp',
     'admincp',


### PR DESCRIPTION
Removing django_cleanup module. It does not needed anymore.

Change-Id: I937bfb07f4d74f249c814693589f775656e9d4bc