### PR TITLE
Split Settings - Some Privacy for Our Secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+palamar/local_settings.py
 files/
 .idea/
 .Trash-1000/
@@ -65,3 +66,4 @@ target/
 .ipynb_checkpoints
 docs/
 /static/avatar/
+palamar/local_settings.py

--- a/conf/local_settings.py.template
+++ b/conf/local_settings.py.template
@@ -1,0 +1,2 @@
+LOCAL_SETTINGS = True
+from settings import *

--- a/palamar/settings.py
+++ b/palamar/settings.py
@@ -265,3 +265,11 @@ SOCIAL_AUTH_GITHUB_KEY = '07d27678fffaa29bc2cc'
 # SECURITY WARNING: keep the secret key used in production secret!
 SOCIAL_AUTH_GITHUB_SECRET = '23991546f87c828ed1e5699a48641c3b99daeae9'
 
+# split settings
+try:
+    LOCAL_SETTINGS
+except NameError:
+    try:
+        from local_settings import *
+    except ImportError:
+        pass


### PR DESCRIPTION
Without a split settings our secrets were bare on public repo.
This will cover their modesty and will give them some privacy.